### PR TITLE
fix(interpolation): Fix issue with overshoot in interpolation at edge…

### DIFF
--- a/__tests__/__snapshots__/index.js.snap
+++ b/__tests__/__snapshots__/index.js.snap
@@ -15,12 +15,12 @@ Object {
       "first-coordinates": Object {
         "first": Object {
           "first": Object {
-            "first": -86.65809631,
+            "first": NaN,
             "last": 40.00868344,
             "length": 2,
           },
           "last": Object {
-            "first": -86.65809631,
+            "first": NaN,
             "last": 40.00868344,
             "length": 2,
           },
@@ -28,12 +28,12 @@ Object {
         },
         "last": Object {
           "first": Object {
-            "first": -86.65809631,
+            "first": NaN,
             "last": 40.00868344,
             "length": 2,
           },
           "last": Object {
-            "first": -86.65809631,
+            "first": NaN,
             "last": 40.00868344,
             "length": 2,
           },
@@ -44,12 +44,12 @@ Object {
       "last-coordinates": Object {
         "first": Object {
           "first": Object {
-            "first": -86.65809631,
+            "first": NaN,
             "last": 40.00868344,
             "length": 2,
           },
           "last": Object {
-            "first": -86.65809631,
+            "first": NaN,
             "last": 40.00868344,
             "length": 2,
           },
@@ -57,12 +57,12 @@ Object {
         },
         "last": Object {
           "first": Object {
-            "first": -86.65809631,
+            "first": NaN,
             "last": 40.00868344,
             "length": 2,
           },
           "last": Object {
-            "first": -86.65809631,
+            "first": NaN,
             "last": 40.00868344,
             "length": 2,
           },

--- a/index.js
+++ b/index.js
@@ -181,7 +181,8 @@ export default function jsolines ({
           startx,
           starty,
           surface,
-          width
+          width,
+          height
         })
         if (!coord) break
 
@@ -248,7 +249,8 @@ function interpolate ({
   startx,
   starty,
   surface,
-  width
+  width,
+  height
 }: {
   coord: Coordinate,
   cutoff: number,
@@ -256,14 +258,21 @@ function interpolate ({
   startx: number,
   starty: number,
   surface: Uint8Array,
-  width: number
+  width: number,
+  height: number
 }): (Coordinate | void) {
   const [x, y] = coord
   const index = y * width + x
-  const topLeft = surface[index]
-  const topRight = surface[index + 1]
-  const botLeft = surface[index + width]
-  const botRight = surface[index + width + 1]
+  let topLeft = surface[index]
+  let topRight = surface[index + 1]
+  let botLeft = surface[index + width]
+  let botRight = surface[index + width + 1]
+
+  // The edges are always considered unreachable to avoid edge effects
+  if (x === 0) topLeft = botLeft = Infinity
+  if (y === 0) topLeft = topRight = Infinity
+  if (y === height - 2) botRight = botLeft = Infinity
+  if (x === width - 2) topRight = botRight = Infinity
 
   // do linear interpolation
   if (startx < x) {


### PR DESCRIPTION
…s of region.

The problem was that we set all the values around the edge of the grid to infinity when doing the contouring so that isochrones are always closed, but we weren't doing the same for the interpolation code.

Fixes #24.