### PR TITLE
Fix nan check

### DIFF
--- a/__tests__/__snapshots__/index.js.snap
+++ b/__tests__/__snapshots__/index.js.snap
@@ -15,12 +15,12 @@ Object {
       "first-coordinates": Object {
         "first": Object {
           "first": Object {
-            "first": NaN,
+            "first": -86.65603638,
             "last": 40.00868344,
             "length": 2,
           },
           "last": Object {
-            "first": NaN,
+            "first": -86.65603638,
             "last": 40.00868344,
             "length": 2,
           },
@@ -28,12 +28,12 @@ Object {
         },
         "last": Object {
           "first": Object {
-            "first": NaN,
+            "first": -86.65603638,
             "last": 40.00868344,
             "length": 2,
           },
           "last": Object {
-            "first": NaN,
+            "first": -86.65603638,
             "last": 40.00868344,
             "length": 2,
           },
@@ -44,12 +44,12 @@ Object {
       "last-coordinates": Object {
         "first": Object {
           "first": Object {
-            "first": NaN,
+            "first": -86.65603638,
             "last": 40.00868344,
             "length": 2,
           },
           "last": Object {
-            "first": NaN,
+            "first": -86.65603638,
             "last": 40.00868344,
             "length": 2,
           },
@@ -57,12 +57,12 @@ Object {
         },
         "last": Object {
           "first": Object {
-            "first": NaN,
+            "first": -86.65603638,
             "last": 40.00868344,
             "length": 2,
           },
           "last": Object {
-            "first": NaN,
+            "first": -86.65603638,
             "last": 40.00868344,
             "length": 2,
           },

--- a/index.js
+++ b/index.js
@@ -279,8 +279,8 @@ function interpolate ({
     // came from left
     let frac = interpolation ? (cutoff - topLeft) / (botLeft - topLeft) : 0.5
 
-    if (frac === Infinity) {
-      debug(`segment fraction from left is Infinity at ${x}, ${y}; if this is at the edge of the query this is not totally unexpected.`)
+    if (isNaN(frac) || frac === Infinity) {
+      debug(`segment fraction from left is ${frac} at ${x}, ${y}; if this is at the edge of the query this is not totally unexpected.`)
       frac = 0.5
     }
 
@@ -289,8 +289,8 @@ function interpolate ({
     // came from right
     let frac = interpolation ? (cutoff - topRight) / (botRight - topRight) : 0.5
 
-    if (frac === Infinity) {
-      debug(`segment fraction from right is Infinity at ${x}, ${y}; if this is at the edge of the query this is not totally unexpected.`)
+    if (isNaN(frac) || frac === Infinity) {
+      debug(`segment fraction from right is ${frac} at ${x}, ${y}; if this is at the edge of the query this is not totally unexpected.`)
       frac = 0.5
     }
 
@@ -299,8 +299,8 @@ function interpolate ({
     // came from bottom
     let frac = interpolation ? (cutoff - botLeft) / (botRight - botLeft) : 0.5
 
-    if (frac === Infinity) {
-      debug(`segment fraction from bottom is Infinity at ${x}, ${y}; if this is at the edge of the query this is not totally unexpected.`)
+    if (isNaN(frac) || frac === Infinity) {
+      debug(`segment fraction from bottom is ${frac} at ${x}, ${y}; if this is at the edge of the query this is not totally unexpected.`)
       frac = 0.5
     }
 
@@ -309,8 +309,8 @@ function interpolate ({
     // came from top
     let frac = interpolation ? (cutoff - topLeft) / (topRight - topLeft) : 0.5
 
-    if (frac === Infinity) {
-      debug(`segment fraction from top is Infinity at ${x}, ${y}; if this is at the edge of the query this is not totally unexpected.`)
+    if (isNaN(frac) || frac === Infinity) {
+      debug(`segment fraction from top is ${frac} at ${x}, ${y}; if this is at the edge of the query this is not totally unexpected.`)
       frac = 0.5
     }
 


### PR DESCRIPTION
Updated out of bounds checking was not properly done. Tests showed that with a `NaN` value in the results. This finishes the out of bounds checking by checking for `NaN`.

@evansiroky feel free to review later, but I am going to merge this in as I need it and it was a pretty clear bugfix.