### PR TITLE
Remove 1D objects processed as holes.

### DIFF
--- a/index.js
+++ b/index.js
@@ -157,16 +157,24 @@ export default function jsolines ({
 
   // Shell game time. Sort out shells and holes.
   holes.forEach((hole) => {
-    // NB this is checking whether the first coordinate of the hole is inside
-    // the shell. This is sufficient as shells don't overlap, and holes are
-    // guaranteed to be completely contained by a single shell.
-    const holePoint = point(hole.geometry.coordinates[0][0])
-    const containingShell = shells.find((shell) => inside(holePoint, shell))
+    // Only accept holes that are at least 2-dimensional.
+    const vertices = Object.keys(hole.geometry.coordinates[0].reduce((unique, [lat, lng]) => {
+      unique[`${lat}-${lng}`] = null
+      return unique
+    }, {}))
 
-    if (containingShell) {
-      containingShell.geometry.coordinates.push(hole.geometry.coordinates[0])
-    } else {
-      logError('Did not find fitting shell for hole')
+    if (vertices.length >= 3) {
+      // NB this is checking whether the first coordinate of the hole is inside
+      // the shell. This is sufficient as shells don't overlap, and holes are
+      // guaranteed to be completely contained by a single shell.
+      const holePoint = point(hole.geometry.coordinates[0][0])
+      const containingShell = shells.find((shell) => inside(holePoint, shell))
+
+      if (containingShell) {
+        containingShell.geometry.coordinates.push(hole.geometry.coordinates[0])
+      } else {
+        logError('Did not find fitting shell for hole')
+      }
     }
   })
 


### PR DESCRIPTION
We remove any possible 1D artifacts from isolines by ensuring that holes contain at least 3 vertices.

Resolves #42 